### PR TITLE
Improve tests, add downloading barcodes, and a new barcode list format.

### DIFF
--- a/seqspec/seqspec_check.py
+++ b/seqspec/seqspec_check.py
@@ -43,7 +43,7 @@ def validate_check_args(parser, args):
         else:
             print("\n".join(errors))
 
-    return
+    return len(errors)
 
 
 def run_check(schema, spec, spec_fn):

--- a/seqspec/seqspec_onlist.py
+++ b/seqspec/seqspec_onlist.py
@@ -66,7 +66,7 @@ def run_onlist(spec: Assay, modality: str, region_id: str):
     regions = run_find_by_type(spec, modality, region_id)
     onlists = []
     for r in regions:
-        onlists.append(r.get_onlist().filename)
+        onlists.append(r.get_onlist())
 
     return join_onlists(onlists)
 
@@ -86,11 +86,26 @@ def run_list_onlists(spec: Assay, modality: str):
     return olsts
 
 
+def find_list_target_dir(onlists):
+    for l in onlists:
+        if l.location == "local":
+            base_path = os.path.dirname(os.path.abspath(onlists[0].filename))
+            if os.access(base_path, os.W_OK):
+                return base_path
+
+    return os.getcwd()
+
+
 def join_onlists(onlists):
-    base_path = os.path.dirname(os.path.abspath(onlists[0]))
-    if len(onlists) == 1:
-        return onlists[0]
+    """Given a list of onlist objects return a file containing the combined list
+    """
+    if len(onlists) == 0:
+        print("No lists present")
+        return
+    elif len(onlists) == 1:
+        return onlists[0].filename
     else:
+        base_path = find_list_target_dir(onlists)
         # join the onlists
         lsts = [read_list(o) for o in onlists]
         joined_path = os.path.join(base_path, "onlist_joined.txt")

--- a/seqspec/seqspec_onlist.py
+++ b/seqspec/seqspec_onlist.py
@@ -102,7 +102,7 @@ def join_onlists(onlists):
     if len(onlists) == 0:
         print("No lists present")
         return
-    elif len(onlists) == 1:
+    elif len(onlists) == 1 and onlists[0].location.lower() == "local":
         return onlists[0].filename
     else:
         base_path = find_list_target_dir(onlists)

--- a/seqspec/seqspec_onlist.py
+++ b/seqspec/seqspec_onlist.py
@@ -32,6 +32,14 @@ def setup_onlist_args(parser):
     subparser_required.add_argument(
         "-r", metavar="REGION", help=("Region"), type=str, default=None, required=False
     )
+    subparser.add_argument(
+        "-f",
+        metavar="FORMAT",
+        type=str,
+        default="product",
+        choices=["product", "multi"],
+        help="select between cartesian product 'product' or multiple barcode lists in file 'multi'"
+    )
     subparser.add_argument("--list", action="store_true", help=("List onlists"))
     return subparser
 
@@ -41,6 +49,7 @@ def validate_onlist_args(parser, args):
     fn = args.yaml
     m = args.m
     r = args.r
+    f = args.f
     # TODO: if onlist is a link, download. also fix output path
     # o = args.o
     # load spec
@@ -54,12 +63,12 @@ def validate_onlist_args(parser, args):
             print(f"{ol['region_id']}\t{ol['filename']}\t{ol['location']}\t{ol['md5']}")
         return
 
-    olist = run_onlist(spec, m, r)
+    olist = run_onlist(spec, m, r, f)
     print(os.path.join(os.path.dirname(os.path.abspath(fn)), olist))
     return
 
 
-def run_onlist(spec: Assay, modality: str, region_id: str):
+def run_onlist(spec: Assay, modality: str, region_id: str, fmt: str):
     # for now return the path to the onlist file for the modality/region pair
 
     # run function
@@ -68,7 +77,7 @@ def run_onlist(spec: Assay, modality: str, region_id: str):
     for r in regions:
         onlists.append(r.get_onlist())
 
-    return join_onlists(onlists)
+    return join_onlists(onlists, fmt)
 
 
 def run_list_onlists(spec: Assay, modality: str):
@@ -96,7 +105,7 @@ def find_list_target_dir(onlists):
     return os.getcwd()
 
 
-def join_onlists(onlists):
+def join_onlists(onlists, fmt):
     """Given a list of onlist objects return a file containing the combined list
     """
     if len(onlists) == 0:
@@ -109,7 +118,27 @@ def join_onlists(onlists):
         # join the onlists
         lsts = [read_list(o) for o in onlists]
         joined_path = os.path.join(base_path, "onlist_joined.txt")
+        formatter_functions = {
+            "product": join_product_onlist,
+            "multi": join_multi_onlist,
+        }
+        formatter = formatter_functions.get(fmt)
+        if formatter is None:
+            raise ValueError("Unrecognized format type {}. Expected".format(
+                fmt, list(formatter_functions.keys())))
+
         with open(joined_path, "w") as f:
-            for i in itertools.product(*lsts):
-                f.write(f"{''.join(i)}\n")
+            for line in formatter(lsts):
+                f.write(line)
+
         return joined_path
+
+
+def join_product_onlist(lsts):
+    for i in itertools.product(*lsts):
+        yield f"{''.join(i)}\n"
+
+
+def join_multi_onlist(lsts):
+    for row in itertools.zip_longest(*lsts, fillvalue='-'):
+        yield f"{' '.join((str(x) for x in row))}\n"

--- a/seqspec/seqspec_print.py
+++ b/seqspec/seqspec_print.py
@@ -151,7 +151,8 @@ def plot_png(assay, modalities, modes, nmodes, lengths):
         ax.set(**{"xlim": (0, max(lengths))})
 
         # hide the spines
-        ax.spines[["right", "top", "left", "bottom"]].set_visible(False)
+        for spine in ["right", "top", "left", "bottom"]:
+            ax.spines[spine].set_visible(False)
         # Hide the axis and ticks and labels
         ax.xaxis.set_visible(False)
         ax.set_yticklabels([])
@@ -162,7 +163,7 @@ def plot_png(assay, modalities, modes, nmodes, lengths):
 
     # adjust the xaxis for the last modality to show the length
     ax.xaxis.set_visible(True)
-    ax.spines[["bottom"]].set_visible(True)
+    ax.spines["bottom"].set_visible(True)
     ax.minorticks_on()
 
     ax.set(

--- a/seqspec/utils.py
+++ b/seqspec/utils.py
@@ -1,4 +1,5 @@
 import io
+import gzip
 from seqspec.Assay import Assay
 import yaml
 import requests
@@ -44,9 +45,32 @@ def write_read(header, seq, qual, f):
     f.write(f"{header}\n{seq}\n+\n{qual}\n")
 
 
-def read_list(fname):
-    with open(fname, "r") as f:
-        return [line.strip() for line in f.readlines()]
+def yield_onlist_contents(stream):
+    for line in stream:
+        yield line.strip().split()[0]
+
+
+def read_list(onlist):
+    """Given an onlist object read the local or remote data
+    """
+    if onlist.location == "remote":
+        response = requests.get(onlist.filename, stream=True)
+        response.raise_for_status()
+        # TODO: instead of just looking at the filename, should we check the content-type?
+        if onlist.filename.endswith(".gz"):
+            stream = io.TextIOWrapper(gzip.GzipFile(fileobj=response.raw))
+        else:
+            stream = response.raw
+        return list(yield_onlist_contents(stream))
+    elif onlist.location == "local" and onlist.filename.endswith(".gz"):
+        with gzip.open(onlist.filename, "rt") as f:
+            return list(yield_onlist_contents(f))
+    elif onlist.location == "local":
+        with open(onlist.filename, "rt") as f:
+            # just get the first column
+            return list(yield_onlist_contents(f))
+    else:
+        raise ValueError("Unsupported location {}. Expected remote or local".format(onlist.location))
 
 
 def region_ids_in_spec(seqspec, modality, region_ids):

--- a/seqspec/utils.py
+++ b/seqspec/utils.py
@@ -69,6 +69,7 @@ def file_exists(uri):
 REGION_TYPE_COLORS = {
     "barcode": "#2980B9",
     "cdna": "#8E44AD",
+    "custom_primer": "#3CB371",
     "fastq": "#F1C40F",
     "gdna": "#E67E22",
     "illumina_p5": "#E17A47",

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,3 +24,4 @@ commands = pytest --cov=seqspec {posargs:tests}
 deps = 
 	pytest
 	pytest-cov
+        matplotlib >= 3.4.0

--- a/tests/test_seqspec_onlist.py
+++ b/tests/test_seqspec_onlist.py
@@ -1,0 +1,24 @@
+import os
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+from seqspec.Region import Onlist
+from seqspec.seqspec_onlist import find_list_target_dir
+
+
+class TestSeqspecOnlist(TestCase):
+    def test_find_list_target_dir_local(self):
+        with TemporaryDirectory(prefix="onlist_tmp_") as tmpdir:
+            filename = os.path.join(tmpdir, "temp.txt")
+            
+            onlist1 = Onlist(filename, "d41d8cd98f00b204e9800998ecf8427e", "local")
+
+            target_dir = find_list_target_dir([onlist1])
+            self.assertEqual(target_dir, tmpdir)
+
+    def test_find_list_target_dir_remote(self):
+        onlist1 = Onlist("http:localhost:9/temp.txt", "d41d8cd98f00b204e9800998ecf8427e", "remote")
+
+        target_dir = find_list_target_dir([onlist1])
+        self.assertEqual(target_dir, os.getcwd())
+        

--- a/tests/test_seqspec_onlist.py
+++ b/tests/test_seqspec_onlist.py
@@ -3,7 +3,11 @@ from tempfile import TemporaryDirectory
 from unittest import TestCase
 
 from seqspec.Region import Onlist
-from seqspec.seqspec_onlist import find_list_target_dir
+from seqspec.seqspec_onlist import (
+    find_list_target_dir,
+    join_product_onlist,
+    join_multi_onlist,
+)
 
 
 class TestSeqspecOnlist(TestCase):
@@ -22,3 +26,26 @@ class TestSeqspecOnlist(TestCase):
         target_dir = find_list_target_dir([onlist1])
         self.assertEqual(target_dir, os.getcwd())
         
+    def test_join_product_onlist(self):
+        onlists = [
+            ["AAAA", "TTTT"],
+            ["GGGG", "CCCC"],
+        ]
+
+        joined = list(join_product_onlist(onlists))
+        self.assertEqual(len(joined), 4)
+        self.assertEqual(joined[0], "AAAAGGGG\n")
+        self.assertEqual(joined[3], "TTTTCCCC\n")
+
+    def test_join_multi_onlist(self):
+        onlists = [
+            ["AAAA", "TTTT"],
+            ["GGGG", "CCCC", "GGTT"],
+        ]
+
+        joined = list(join_multi_onlist(onlists))
+        self.assertEqual(len(joined), 3)
+        self.assertEqual(joined[0], "AAAA GGGG\n")
+        self.assertEqual(joined[1], "TTTT CCCC\n")
+        self.assertEqual(joined[2], "- GGTT\n")
+

--- a/tests/test_seqspec_print.py
+++ b/tests/test_seqspec_print.py
@@ -1,0 +1,31 @@
+from argparse import ArgumentParser
+from io import StringIO
+from tempfile import TemporaryDirectory
+from unittest import TestCase, skipUnless
+from unittest.mock import patch
+
+from matplotlib.figure import Figure
+
+from seqspec.seqspec_print import (
+    run_print_tree,
+    run_print_png,
+)
+from seqspec.utils import (
+    load_spec_stream
+)
+
+from .test_utils import example_spec as example_spec_text
+
+
+class TestSeqspecPrint(TestCase):
+    def setUp(self):
+        self.example_spec  = load_spec_stream(StringIO(example_spec_text))
+
+    def test_seqspec_print_tree(self):
+        tree = run_print_tree(self.example_spec)
+        self.assertIn("SOLiD_P1_adapter", tree)
+
+    def test_seqspec_print_png(self):
+        fig = run_print_png(self.example_spec)
+
+        self.assertIsInstance(fig, Figure)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,18 +12,21 @@ from .test_region import (
 )
 
 example_spec = """!Assay
+seqspec_version: 0.0.0
+assay: test_assay
 name: my assay
 doi: https://doi.org/10.1038/nmeth.1315
 publication_date: 06 April 2009
 description: first method to sequence the whole transcriptome (mRNA) of a single cell
+sequencer: custom
 modalities:
-- RNA
+- rna
 lib_struct: https://teichlab.github.io/scg_lib_structs/methods_html/tang2009.html
 assay_spec:
 - !Region
-  region_id: RNA
-  region_type: RNA
-  name: RNA
+  region_id: rna
+  region_type: rna
+  name: rna
   sequence_type: joined
   sequence: CCACTACGCCTCCGCTTTCCTCTCTATGGGCAGTCGGTGATXCGCCTTGGCCGTACAGCAGNNNNNNAGAGAATGAGGAACCCGGGGCAG
   min_len: 90
@@ -31,19 +34,19 @@ assay_spec:
   onlist: null
   regions:
   - !Region
-    region_id: SOLiD_P1_adaptor
-    region_type: SOLiD_P1_adaptor
-    name: SOLiD_P1_adaptor
+    region_id: SOLiD_P1_adapter
+    region_type: custom_primer
+    name: SOLiD_P1_adapter
     sequence_type: fixed
     sequence: CCACTACGCCTCCGCTTTCCTCTCTATGGGCAGTCGGTGAT
     min_len: 41
     max_len: 41
     onlist: null
     regions: null
-    parent_id: RNA
+    parent_id: rna
   - !Region
     region_id: cDNA
-    region_type: cDNA
+    region_type: cdna
     name: cDNA
     sequence_type: random
     sequence: X
@@ -51,10 +54,10 @@ assay_spec:
     max_len: 98
     onlist: null
     regions: null
-    parent_id: RNA
+    parent_id: rna
   - !Region
     region_id: SOLiD_bc_adapter
-    region_type: SOLiD_bc_adapter
+    region_type: linker
     name: SOLiD_bc_adapter
     sequence_type: fixed
     sequence: CGCCTTGGCCGTACAGCAG
@@ -62,10 +65,10 @@ assay_spec:
     max_len: 19
     onlist: null
     regions: null
-    parent_id: RNA
+    parent_id: rna
   - !Region
     region_id: index
-    region_type: index
+    region_type: barcode
     name: index
     sequence_type: onlist
     sequence: NNNNNN
@@ -73,13 +76,13 @@ assay_spec:
     max_len: 6
     onlist: !Onlist
       filename: index_onlist.txt
-      md5: null
+      md5: 939cb244b4c43248fcc795bbe79599b0
       location: local
     regions: null
-    parent_id: RNA
+    parent_id: rna
   - !Region
     region_id: p2_adapter
-    region_type: p2_adapter
+    region_type: custom_primer
     name: p2_adapter
     sequence_type: fixed
     sequence: AGAGAATGAGGAACCCGGGGCAG
@@ -87,7 +90,7 @@ assay_spec:
     max_len: 23
     onlist: null
     regions: null
-    parent_id: RNA
+    parent_id: rna
 """
 
 
@@ -96,7 +99,7 @@ class TestUtils(TestCase):
         with StringIO(example_spec) as instream:
             spec = load_spec_stream(instream)
         self.assertEqual(spec.name, "my assay")
-        head = spec.get_modality("RNA")
+        head = spec.get_modality("rna")
         self.assertEqual(len(head.regions), 5)
 
     def test_get_cuts(self):


### PR DESCRIPTION
Hi,

In this commit history I added support for older versions of matplotlib, fixed up some of the tests that were disabled when the example assays got split to a different repository, and I added some tests to seqspec print. I also had to add a new color because my small example used the "custom_primer" type which didn't have a color assigned. 

As for the useful onlist barcode features
I added code to download remote barcode lists and put them into a local file, including on the fly decompression of gzip files if the url ends in .gz.
I then added code to output barcode files in kallistos multiple barcode lists are stored in one file separated by spaces. It keeps the current behavior as the default, but adds an option to switch to the kallisto format.

This history is based on the current main and doesn't involve the libspec changes.

Let me know if there's any adjustments you'd like to make it a better choice to merge.
