### PR TITLE
Libspec local caching

### DIFF
--- a/seqspec/seqspec_onlist.py
+++ b/seqspec/seqspec_onlist.py
@@ -3,7 +3,7 @@ from seqspec.Region import project_regions_to_coordinates, itx_read, Onlist
 from seqspec.utils import load_spec, map_read_id_to_regions
 from seqspec.seqspec_find import run_find_by_type, run_find
 import os
-from seqspec.utils import read_list
+from seqspec.utils import read_list, find_onlist_file
 import itertools
 from typing import List
 
@@ -167,8 +167,11 @@ def join_onlists(onlists: List[Onlist], fmt: str):
     if len(onlists) == 0:
         print("No lists present")
         return
-    elif len(onlists) == 1 and onlists[0].location.lower() == "local":
-        return onlists[0].filename
+
+    # look to see if the barcode file is present.
+    first_location, first_filename = find_onlist_file(onlists[0])
+    if len(onlists) == 1 and first_location == "local":
+        return first_filename
     else:
         base_path = find_list_target_dir(onlists)
         # join the onlists

--- a/seqspec/utils.py
+++ b/seqspec/utils.py
@@ -1,4 +1,5 @@
 import io
+import os
 import gzip
 from pathlib import Path
 from seqspec.Assay import Assay
@@ -67,7 +68,8 @@ def read_list(onlist: Onlist):
     try:
         # open stream
         if location == "remote":
-            response = requests.get(filename, stream=True)
+            auth = get_remote_auth_token()
+            response = requests.get(filename, stream=True, auth=auth)
             response.raise_for_status()
             stream = response.raw
         elif location == "local":
@@ -109,6 +111,19 @@ def find_onlist_file(onlist: Onlist):
     else:
         raise FileNotFoundError(
             "No such {} file {}".format(onlist.location, onlist.filename))
+
+
+def get_remote_auth_token():
+    """Look for authentication tokens for accessing remote resources
+    """
+    username = os.environ.get("IGVF_API_KEY")
+    password = os.environ.get("IGVF_SECRET_KEY")
+    if not (username is None or password is None):
+        auth = (username, password)
+    else:
+        auth = None
+
+    return auth
 
 
 def region_ids_in_spec(seqspec, modality, region_ids):

--- a/tests/test_seqspec_onlist.py
+++ b/tests/test_seqspec_onlist.py
@@ -14,12 +14,13 @@ from seqspec.seqspec_onlist import (
 from seqspec.utils import load_spec_stream
 from .test_utils import example_spec
 
+
 class TestSeqspecOnlist(TestCase):
     def test_run_onlist_region(self):
         with StringIO(example_spec) as instream:
             spec = load_spec_stream(instream)
         # returns the one local barcode path
-        regions = run_onlist_region(spec, "rna", "barcode", "multi")
+        regions = run_onlist_region(spec, "rna", "index", "multi")
         self.assertEqual(regions, "index_onlist.txt")
 
     def test_run_onlist_read(self):

--- a/tests/test_seqspec_onlist.py
+++ b/tests/test_seqspec_onlist.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from io import StringIO
 import os
 from tempfile import TemporaryDirectory
@@ -6,6 +7,7 @@ from unittest import TestCase
 from seqspec.Region import Onlist
 from seqspec.seqspec_onlist import (
     find_list_target_dir,
+    join_onlists,
     join_product_onlist,
     join_multi_onlist,
     run_onlist_region,
@@ -15,23 +17,42 @@ from seqspec.utils import load_spec_stream
 from .test_utils import example_spec
 
 
+@contextmanager
+def create_temporary_barcode_files(filenames):
+    if isinstance(filenames, str):
+        filenames = [filenames]
+
+    cwd = os.getcwd()
+    try:
+        with TemporaryDirectory(prefix="test_onlist_") as tmpdir:
+            os.chdir(tmpdir)
+            for name in filenames:
+                filename = os.path.join(tmpdir, name)
+                with open(filename, "wt") as outstream:
+                    pass
+            yield tmpdir
+    finally:
+        os.chdir(cwd)
+
+
 class TestSeqspecOnlist(TestCase):
     def test_run_onlist_region(self):
-        with StringIO(example_spec) as instream:
-            spec = load_spec_stream(instream)
-        # returns the one local barcode path
-        regions = run_onlist_region(spec, "rna", "index", "multi")
-        self.assertEqual(regions, "index_onlist.txt")
+        with create_temporary_barcode_files(["index_onlist.txt"]):
+            with StringIO(example_spec) as instream:
+                spec = load_spec_stream(instream)
+            # returns the one local barcode path
+            regions = run_onlist_region(spec, "rna", "index", "multi")
+            self.assertEqual(regions, "index_onlist.txt")
 
     def test_run_onlist_read(self):
-        with StringIO(example_spec) as instream:
-            spec = load_spec_stream(instream)
-        # Returns the one local barcode path
-        reads = run_onlist_read(spec, "rna", "read2.fastq.gz", "multi")
-        self.assertEqual(reads, "index_onlist.txt")
+        with create_temporary_barcode_files(["index_onlist.txt"]):
+            with StringIO(example_spec) as instream:
+                spec = load_spec_stream(instream)
+            reads = run_onlist_read(spec, "rna", "read2.fastq.gz", "multi")
+            self.assertEqual(reads, "index_onlist.txt")
 
     def test_find_list_target_dir_local(self):
-        with TemporaryDirectory(prefix="onlist_tmp_") as tmpdir:
+        with create_temporary_barcode_files(["index_onlist.txt"]) as tmpdir:
             filename = os.path.join(tmpdir, "temp.txt")
 
             onlist1 = Onlist(filename, "d41d8cd98f00b204e9800998ecf8427e", "local")
@@ -44,6 +65,30 @@ class TestSeqspecOnlist(TestCase):
 
         target_dir = find_list_target_dir([onlist1])
         self.assertEqual(target_dir, os.getcwd())
+
+    def test_join_one_list_remote_cached_locally(self):
+        with create_temporary_barcode_files(["index_onlist.txt"]):
+            # Can we find a local copy of a  remote list?
+            onlist_name = "index_onlist.txt"
+            onlist1 = Onlist(
+                "http:localhost:9/{}".format(onlist_name),
+                "d41d8cd98f00b204e9800998ecf8427e",
+                "remote")
+
+            filename = join_onlists([onlist1], "multi")
+            self.assertEqual(filename, onlist_name)
+
+    def test_join_multiple_lists_remote_cached_locally(self):
+        # Can we find a local copy of a  remote list?
+        with create_temporary_barcode_files(["index_onlist.txt"]) as tmpdir:
+            onlist_name = "index_onlist.txt"
+            onlist1 = Onlist(
+                "http:localhost:9/{}".format(onlist_name),
+                "d41d8cd98f00b204e9800998ecf8427e",
+                "remote")
+
+            filename = join_onlists([onlist1, onlist1], "multi")
+            self.assertEqual(filename, os.path.join(tmpdir, "onlist_joined.txt"))
 
     def test_join_product_onlist(self):
         onlists = [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -239,7 +239,7 @@ class TestUtils(TestCase):
         def fake_request_get(url, stream=False, **kwargs):
             class response:
                 def __init__(self):
-                    self.raw = StringIO(fake_contents)
+                    self.raw = BytesIO(fake_contents.encode("utf-8"))
                     self.status_code = 200
 
                 def raise_for_status(self):


### PR DESCRIPTION
Siddarth from the Broad asked if the barcode downloading code could check to see if the file is already downloaded and use the local copy if available. (Partially to get around the problems of barcode files that are on the portal but haven't been released.)

I made that change, fixed a couple of minor bugs and went ahead and added reading the IGVF environment variables for providing authentication tokens if needed to access urls.

Later he pointed out that my first implmentation made a slight change in that it always copied remote barcode files into onlist_joined.txt even if they were locally cached.

Today's commit puts checking for already existing local copies of files earlier so if there's only one barcode file, and it's already present it can just return the filename instead of copying it.