### PR TITLE
Fixes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.2.x] - XXXX-XX-XX
+
+### Changed
+
+- Modified the internals of `seqspec onlist` to manage saving the joined onlist to the `-o` location when specified (otherwise saves to path where spec lives).
+
+### Added
+
+- Add typing hints to many `Assay` and `Region` functions
+
+### Removed
+
+### Fixed
+
 ## [0.2.0] - 2024-04-17
 
 ### Changed

--- a/seqspec/Assay.py
+++ b/seqspec/Assay.py
@@ -96,7 +96,7 @@ class Assay(yaml.YAMLObject):
         for r in self.library_spec:
             r.update_attr()
 
-    def get_libspec(self, modality):
+    def get_libspec(self, modality) -> Region:
         return self.library_spec[self.modalities.index(modality)]
 
     def get_seqspec(self, modality):

--- a/seqspec/Assay.py
+++ b/seqspec/Assay.py
@@ -1,6 +1,6 @@
 import yaml
 from seqspec.Region import Region, Read
-from typing import List
+from typing import List, Optional
 import json
 from . import __version__
 
@@ -83,9 +83,18 @@ class Assay(yaml.YAMLObject):
         return json.dumps(self, default=lambda o: o.__dict__, sort_keys=False, indent=4)
 
     # note to_yaml is reserved for yaml.YAMLObject
-    def to_YAML(self, fname: str):
-        with open(fname, "w") as f:
-            yaml.dump(self, f, sort_keys=False)
+    def to_YAML(self, fname: Optional[str]=None):
+        """Export seqspec to yaml
+
+        If fname is provided, the seqspec text will be written to the
+        file.
+        If fname is None, the seqspec text will be returned as a string.
+        """
+        if fname is None:
+            return yaml.dump(self, sort_keys=False)
+        else:
+            with open(fname, "w") as f:
+                yaml.dump(self, f, sort_keys=False)
 
     def print_sequence(self):
         for region in self.library_spec:

--- a/seqspec/Region.py
+++ b/seqspec/Region.py
@@ -64,7 +64,7 @@ class Region(yaml.YAMLObject):
             max_l += self.max_len
         return (min_l, max_l)
 
-    def get_onlist(self):
+    def get_onlist(self) -> Optional["Onlist"]:
         return self.onlist
 
     def update_attr(self):
@@ -129,7 +129,9 @@ class Region(yaml.YAMLObject):
                 found = r.get_region_by_id(region_id, found)
         return found
 
-    def get_region_by_region_type(self, region_type, found=[]):
+    def get_region_by_region_type(
+        self, region_type: str, found: List["Region"] = []
+    ) -> List["Region"]:
         if not found:
             found = []
         if self.region_type == region_type:
@@ -139,7 +141,7 @@ class Region(yaml.YAMLObject):
                 found = r.get_region_by_region_type(region_type, found)
         return found
 
-    def get_onlist_regions(self, found=[]):
+    def get_onlist_regions(self, found: List["Region"] = []) -> List["Region"]:
         if not found:
             found = []
         if self.onlist is not None:
@@ -149,7 +151,7 @@ class Region(yaml.YAMLObject):
                 found = r.get_onlist_regions(found)
         return found
 
-    def get_leaves(self, leaves=[]):
+    def get_leaves(self, leaves: List["Region"] = []) -> List["Region"]:
         if not leaves:
             leaves = []
         if not self.regions:
@@ -315,7 +317,7 @@ def project_regions_to_coordinates(
 
 def itx_read(
     region_coordinates: List[RegionCoordinate], read_start: int, read_stop: int
-):
+) -> List[RegionCoordinate]:
     # return a list of region_coordinates intersect with read start/stop
     new_rcs = []
 

--- a/seqspec/seqspec_find.py
+++ b/seqspec/seqspec_find.py
@@ -1,6 +1,8 @@
 from seqspec.utils import load_spec
 from seqspec.Assay import Assay
+from seqspec.Region import Region
 import yaml
+from typing import List
 
 
 def setup_find_args(parser):
@@ -73,7 +75,7 @@ def run_find(spec: Assay, modality: str, region_id: str):
     return regions
 
 
-def run_find_by_type(spec: Assay, modality: str, region_type: str):
+def run_find_by_type(spec: Assay, modality: str, region_type: str) -> List[Region]:
     m = spec.get_libspec(modality)
     regions = m.get_region_by_region_type(region_type)
     return regions

--- a/seqspec/seqspec_index.py
+++ b/seqspec/seqspec_index.py
@@ -285,6 +285,17 @@ def format_zumis(indices, subregion_type=None):
     return "\n".join(xl)[:-1]
 
 
+def stable_deduplicate_fqs(fqs):
+    # stably deduplicate gdna_fqs
+    seen_fqs = set()
+    deduplicated_fqs = []
+    for r in fqs:
+        if r not in seen_fqs:
+            deduplicated_fqs.append(r)
+            seen_fqs.add(r)
+    return deduplicated_fqs
+
+
 def format_chromap(indices, subregion_type=None):
     bc_fqs = []
     bc_str = []
@@ -306,8 +317,9 @@ def format_chromap(indices, subregion_type=None):
         raise Exception("chromap only supports genomic dna from two fastqs")
 
     barcode_fq = bc_fqs[0]
-    read1_fq = list(set(gdna_fqs))[0]
-    read2_fq = list(set(gdna_fqs))[1]
+    deduplicated_gdna_fqs = stable_deduplicate_fqs(gdna_fqs)
+    read1_fq = deduplicated_gdna_fqs[0]
+    read2_fq = deduplicated_gdna_fqs[1]
     read_str = ",".join([f"r{idx}:{ele}" for idx, ele in enumerate(gdna_str, 1)])
     bc_str = ",".join(bc_str)
 

--- a/seqspec/seqspec_onlist.py
+++ b/seqspec/seqspec_onlist.py
@@ -3,7 +3,7 @@ from seqspec.Region import project_regions_to_coordinates, itx_read, Onlist
 from seqspec.utils import load_spec, map_read_id_to_regions
 from seqspec.seqspec_find import run_find_by_type, run_find
 import os
-from seqspec.utils import read_list, find_onlist_file
+from seqspec.utils import read_local_list, read_remote_list
 import itertools
 from typing import List
 
@@ -67,8 +67,16 @@ def validate_onlist_args(parser, args):
     m = args.m
     r = args.r
     f = args.f
-    # TODO: if onlist is a link, download. also fix output path
-    # o = args.o
+
+    # the base path is the path to the spec file
+    base_path = os.path.dirname(os.path.abspath(fn))
+
+    # set the save path if it exists
+    save_path = args.o
+    if not save_path:
+        # otherwise the save path is the same path as the spec
+        save_path = base_path
+
     # load spec
     spec = load_spec(fn)
     # if number of barcodes > 1 then we need to join them
@@ -79,68 +87,97 @@ def validate_onlist_args(parser, args):
         for ol in onlists:
             print(f"{ol['region_id']}\t{ol['filename']}\t{ol['location']}\t{ol['md5']}")
         return
-    if args.s == "region":
-        olist = run_onlist_region(spec, m, r, f)
-    elif args.s == "region-type":
-        olist = run_onlist_region_type(spec, m, r, f)
-    elif args.s == "read":
-        olist = run_onlist_read(spec, m, r, f)
-    print(os.path.join(os.path.dirname(os.path.abspath(fn)), olist))
+
+    CMD = {
+        "region": run_onlist_region,
+        "region-type": run_onlist_region_type,
+        "read": run_onlist_read,
+    }
+    if args.s in CMD.keys():
+        onlists = CMD[args.s](spec, m, r)
+    else:
+        raise ValueError(f"Unrecognized spec object {args.s}")
+
+    if len(onlists) == 0:
+        raise ValueError(f"No onlist found for {m}, {args.s}, {r}")
+
+    # for only one onlist we can just return the path
+    # if only one, its remote and we save it to the base path
+    elif len(onlists) == 1:
+        location = onlists[0].location
+        onlist_fn = os.path.basename(onlists[0].filename)
+        if location == "local":
+            onlist_path = os.path.join(base_path, onlist_fn)
+        elif location == "remote":
+            # download the onlist to the base path and return the path
+            onlist_elements = read_remote_list(onlists[0], save_path)
+            onlist_path = os.path.join(
+                write_onlist(onlist_elements, save_path), onlist_fn
+            )
+
+    # anytime we join onlists, we create a new onlist file
+    elif len(onlists) > 1:
+        lsts = []
+        for o in onlists:
+            if o.location == "local":
+                lsts.append(read_local_list(o, base_path))
+            elif o.location == "remote":
+                # base_path is ignored for remote onlists
+                lsts.append(read_remote_list(o, base_path))
+        onlist_elements = join_onlists(onlists, f)
+        onlist_path = os.path.join(
+            write_onlist(onlist_elements, save_path), "onlist_joined.txt"
+        )
+
+    # print the path to the onlist
+    print(onlist_path)
     return
 
 
-def run_onlist_region_type(spec: Assay, modality: str, region_type: str, fmt: str):
-    # for now return the path to the onlist file for the modality/region pair
-
-    # run function
+def run_onlist_region_type(
+    spec: Assay, modality: str, region_type: str
+) -> List[Onlist]:
     regions = run_find_by_type(spec, modality, region_type)
-    onlists = []
+    onlists: List[Onlist] = []
     for r in regions:
-        onlists.append(r.get_onlist())
-    if len(onlists) == 0:
-        raise ValueError(f"No onlist found for region type {region_type}")
-    return join_onlists(onlists, fmt)
+        ol = r.get_onlist()
+        if ol:
+            onlists.append(ol)
+    return onlists
 
 
-def run_onlist_region(spec: Assay, modality: str, region_id: str, fmt: str):
-    # for now return the path to the onlist file for the modality/region pair
-
-    # run function
+def run_onlist_region(spec: Assay, modality: str, region_id: str) -> List[Onlist]:
     regions = run_find(spec, modality, region_id)
-    onlists = []
+    onlists: List[Onlist] = []
     for r in regions:
         onlists.append(r.get_onlist())
     if len(onlists) == 0:
         raise ValueError(f"No onlist found for region {region_id}")
-    return join_onlists(onlists, fmt)
+    return onlists
 
 
-def run_onlist_read(spec: Assay, modality: str, read_id: str, fmt: str):
-    # for now return the path to the onlist file for the modality/region pair
-
-    # run function
+def run_onlist_read(spec: Assay, modality: str, read_id: str) -> List[Onlist]:
     (read, rgns) = map_read_id_to_regions(spec, modality, read_id)
     # convert regions to region coordinates
     rcs = project_regions_to_coordinates(rgns)
     # intersect read with region coordinates
     new_rcs = itx_read(rcs, 0, read.max_len)
 
-    onlists = []
+    onlists: List[Onlist] = []
     for r in new_rcs:
         ol = r.get_onlist()
         if ol:
             onlists.append(ol)
 
-    if len(onlists) == 0:
-        raise ValueError(f"No onlist found for read {read_id}")
-
-    return join_onlists(onlists, fmt)
+    return onlists
 
 
 def run_list_onlists(spec: Assay, modality: str):
     regions = spec.get_libspec(modality).get_onlist_regions()
     olsts = []
     for r in regions:
+        if r.onlist is None:
+            continue
         olsts.append(
             {
                 "region_id": r.region_id,
@@ -162,43 +199,32 @@ def find_list_target_dir(onlists):
     return os.getcwd()
 
 
-def join_onlists(onlists: List[Onlist], fmt: str):
+def join_onlists(onlists: List[List[str]], fmt: str) -> List[str]:
     """Given a list of onlist objects return a file containing the combined list"""
-    if len(onlists) == 0:
-        print("No lists present")
-        return
 
-    # look to see if the barcode file is present.
-    first_location, first_filename = find_onlist_file(onlists[0])
-    if len(onlists) == 1 and first_location == "local":
-        return first_filename
-    else:
-        base_path = find_list_target_dir(onlists)
-        # join the onlists
-        lsts = [read_list(o) for o in onlists]
-        joined_path = os.path.join(base_path, "onlist_joined.txt")
-        formatter_functions = {
-            "product": join_product_onlist,
-            "multi": join_multi_onlist,
-        }
-        formatter = formatter_functions.get(fmt)
-        if formatter is None:
-            raise ValueError(
-                f"Unrecognized format type {fmt}. Expected {', '.join(list(formatter_functions.keys()))}"
-            )
+    # base path should be the path relative to the spec file
+    # join the onlists
+    formatter_functions = {
+        "product": join_product_onlist,
+        "multi": join_multi_onlist,
+    }
+    joined_onlist = list(formatter_functions[fmt](onlists))
 
-        with open(joined_path, "w") as f:
-            for line in formatter(lsts):
-                f.write(line)
-
-        return joined_path
+    return joined_onlist
 
 
-def join_product_onlist(lsts):
+def write_onlist(onlist: List[str], path: str) -> str:
+    with open(path, "w") as f:
+        for line in onlist:
+            f.write(line)
+    return path
+
+
+def join_product_onlist(lsts: List[List[str]]):
     for i in itertools.product(*lsts):
         yield f"{''.join(i)}\n"
 
 
-def join_multi_onlist(lsts):
+def join_multi_onlist(lsts: List[List[str]]):
     for row in itertools.zip_longest(*lsts, fillvalue="-"):
         yield f"{' '.join((str(x) for x in row))}\n"

--- a/seqspec/seqspec_onlist.py
+++ b/seqspec/seqspec_onlist.py
@@ -72,8 +72,9 @@ def validate_onlist_args(parser, args):
     base_path = os.path.dirname(os.path.abspath(fn))
 
     # set the save path if it exists
-    save_path = os.path.abspath(args.o)
-    if not save_path:
+    if args.o:
+        save_path = os.path.abspath(args.o)
+    else:
         # otherwise the save path is the same path as the spec
         save_path = os.path.join(base_path, "onlist_joined.txt")
 

--- a/seqspec/seqspec_onlist.py
+++ b/seqspec/seqspec_onlist.py
@@ -111,7 +111,6 @@ def validate_onlist_args(parser, args):
         elif location == "remote":
             # download the onlist to the base path and return the path
             onlist_elements = read_remote_list(onlists[0])
-            print(onlist_elements)
             onlist_path = write_onlist(onlist_elements, save_path)
 
     # anytime we join onlists, we create a new onlist file

--- a/seqspec/seqspec_onlist.py
+++ b/seqspec/seqspec_onlist.py
@@ -204,9 +204,11 @@ def join_onlists(onlists: List[List[str]], fmt: str) -> List[str]:
         "product": join_product_onlist,
         "multi": join_multi_onlist,
     }
-    joined_onlist = list(formatter_functions[fmt](onlists))
+    jo = []
+    for i in formatter_functions[fmt](onlists):
+        jo.append(i)
 
-    return joined_onlist
+    return jo
 
 
 def write_onlist(onlist: List[str], path: str) -> str:

--- a/seqspec/seqspec_onlist.py
+++ b/seqspec/seqspec_onlist.py
@@ -107,8 +107,10 @@ def validate_onlist_args(parser, args):
     elif len(onlists) == 1:
         location = onlists[0].location
         onlist_fn = os.path.basename(onlists[0].filename)
-        if location == "local":
-            onlist_path = os.path.join(base_path, onlist_fn)
+        onlist_path = os.path.join(base_path, onlist_fn)
+
+        if os.path.exists(onlist_path):
+            location = "local"
         elif location == "remote":
             # download the onlist to the base path and return the path
             onlist_elements = read_remote_list(onlists[0])
@@ -128,7 +130,7 @@ def validate_onlist_args(parser, args):
 
     # print the path to the onlist
     print(onlist_path)
-    return
+    return onlist_path
 
 
 def run_onlist_region_type(

--- a/seqspec/seqspec_onlist.py
+++ b/seqspec/seqspec_onlist.py
@@ -111,6 +111,7 @@ def validate_onlist_args(parser, args):
         elif location == "remote":
             # download the onlist to the base path and return the path
             onlist_elements = read_remote_list(onlists[0])
+            print(onlist_elements)
             onlist_path = write_onlist(onlist_elements, save_path)
 
     # anytime we join onlists, we create a new onlist file
@@ -204,17 +205,15 @@ def join_onlists(onlists: List[List[str]], fmt: str) -> List[str]:
         "product": join_product_onlist,
         "multi": join_multi_onlist,
     }
-    jo = []
-    for i in formatter_functions[fmt](onlists):
-        jo.append(i)
+    joined_onlist = list(formatter_functions[fmt](onlists))
 
-    return jo
+    return joined_onlist
 
 
 def write_onlist(onlist: List[str], path: str) -> str:
     with open(path, "w") as f:
         for line in onlist:
-            f.write(line)
+            f.write(f"{line}\n")
     return path
 
 

--- a/seqspec/seqspec_onlist.py
+++ b/seqspec/seqspec_onlist.py
@@ -72,7 +72,7 @@ def validate_onlist_args(parser, args):
     base_path = os.path.dirname(os.path.abspath(fn))
 
     # set the save path if it exists
-    save_path = args.o
+    save_path = os.path.abspath(args.o)
     if not save_path:
         # otherwise the save path is the same path as the spec
         save_path = base_path

--- a/seqspec/seqspec_onlist.py
+++ b/seqspec/seqspec_onlist.py
@@ -111,8 +111,8 @@ def validate_onlist_args(parser, args):
         elif location == "remote":
             # download the onlist to the base path and return the path
             onlist_elements = read_remote_list(onlists[0], save_path)
-            onlist_path = os.path.join(
-                write_onlist(onlist_elements, save_path), onlist_fn
+            onlist_path = write_onlist(
+                onlist_elements, os.path.join(save_path, onlist_fn)
             )
 
     # anytime we join onlists, we create a new onlist file
@@ -125,8 +125,8 @@ def validate_onlist_args(parser, args):
                 # base_path is ignored for remote onlists
                 lsts.append(read_remote_list(o, base_path))
         onlist_elements = join_onlists(onlists, f)
-        onlist_path = os.path.join(
-            write_onlist(onlist_elements, save_path), "onlist_joined.txt"
+        onlist_path = write_onlist(
+            onlist_elements, os.path.join(save_path, "onlist_joined.txt")
         )
 
     # print the path to the onlist

--- a/seqspec/seqspec_onlist.py
+++ b/seqspec/seqspec_onlist.py
@@ -75,7 +75,7 @@ def validate_onlist_args(parser, args):
     save_path = os.path.abspath(args.o)
     if not save_path:
         # otherwise the save path is the same path as the spec
-        save_path = base_path
+        save_path = os.path.join(base_path, "onlist_joined.txt")
 
     # load spec
     spec = load_spec(fn)
@@ -110,10 +110,8 @@ def validate_onlist_args(parser, args):
             onlist_path = os.path.join(base_path, onlist_fn)
         elif location == "remote":
             # download the onlist to the base path and return the path
-            onlist_elements = read_remote_list(onlists[0], save_path)
-            onlist_path = write_onlist(
-                onlist_elements, os.path.join(save_path, onlist_fn)
-            )
+            onlist_elements = read_remote_list(onlists[0])
+            onlist_path = write_onlist(onlist_elements, save_path)
 
     # anytime we join onlists, we create a new onlist file
     elif len(onlists) > 1:
@@ -125,9 +123,7 @@ def validate_onlist_args(parser, args):
                 # base_path is ignored for remote onlists
                 lsts.append(read_remote_list(o, base_path))
         onlist_elements = join_onlists(onlists, f)
-        onlist_path = write_onlist(
-            onlist_elements, os.path.join(save_path, "onlist_joined.txt")
-        )
+        onlist_path = write_onlist(onlist_elements, save_path)
 
     # print the path to the onlist
     print(onlist_path)

--- a/seqspec/utils.py
+++ b/seqspec/utils.py
@@ -96,7 +96,6 @@ def read_remote_list(onlist: Onlist, base_path: str = "") -> List[str]:
 
         results = []
         for i in yield_onlist_contents(stream):
-            print(i)
             # add the new line when writing to file
             results.append(i)
     finally:

--- a/seqspec/utils.py
+++ b/seqspec/utils.py
@@ -96,6 +96,8 @@ def read_remote_list(onlist: Onlist, base_path: str = "") -> List[str]:
 
         results = []
         for i in yield_onlist_contents(stream):
+            print(i)
+            # add the new line when writing to file
             results.append(i)
     finally:
         if stream is None:

--- a/seqspec/utils.py
+++ b/seqspec/utils.py
@@ -68,7 +68,9 @@ def read_local_list(onlist: Onlist, base_path: str = "") -> List[str]:
     # convert to text stream
     stream = io.TextIOWrapper(stream)
 
-    results = list(yield_onlist_contents(stream))
+    results = []
+    for i in yield_onlist_contents(stream):
+        results.append(i)
     stream.close()
     return results
 
@@ -92,7 +94,9 @@ def read_remote_list(onlist: Onlist, base_path: str = "") -> List[str]:
         # convert to text stream
         stream = io.TextIOWrapper(stream)
 
-        results = list(yield_onlist_contents(stream))
+        results = []
+        for i in yield_onlist_contents(stream):
+            results.append(i)
     finally:
         if stream is None:
             print("Warning: unable to open barcode file {}".format(filename))

--- a/seqspec/utils.py
+++ b/seqspec/utils.py
@@ -204,10 +204,22 @@ def map_read_id_to_regions(
     # get all atomic elements from library
     leaves = spec.get_libspec(modality).get_leaves()
     # get the read object and primer id
-    read = [i for i in spec.sequence_spec if i.read_id == region_id][0]
+    for i in spec.sequence_spec:
+        if i.read_id == region_id:
+            read = i
+            break
+    else:
+        raise IndexError("region_id {} not found in reads {}".format(
+            region_id, [i.read_id for i in spec.sequence_spec]))
     primer_id = read.primer_id
     # get the index of the primer in the list of leaves (ASSUMPTION, 5'->3' and primer is an atomic element)
-    primer_idx = [i for i, l in enumerate(leaves) if l.region_id == primer_id][0]
+    for i, l in enumerate(leaves):
+        if l.region_id == primer_id:
+            primer_idx = i
+            break
+    else:
+        raise IndexError("primer_id {} not found in regions {}".format(
+            primer_id, [l.region_id for l in leaves]))
     # If we are on the opposite strand, we go in the opposite way
     if read.strand == "neg":
         rgns = leaves[:primer_idx][::-1]

--- a/tests/test_assay.py
+++ b/tests/test_assay.py
@@ -1,5 +1,6 @@
 import json
 from unittest import TestCase
+import yaml
 from seqspec.Region import Region
 from seqspec.Assay import Assay
 
@@ -39,6 +40,7 @@ class TestAssay(TestCase):
         self.assertEqual(a.to_dict(), expected)
 
         self.assertEqual(a.to_JSON(), json.dumps(expected, sort_keys=False, indent=4))
+        self.assertTrue(a.to_YAML().startswith("!Assay"))
 
     def test_assay_with_regions(self):
         r_umi_dict = region_rna_umi_dict("region-2")

--- a/tests/test_seqspec_onlist.py
+++ b/tests/test_seqspec_onlist.py
@@ -10,6 +10,7 @@ from seqspec.seqspec_onlist import (
     join_onlists,
     join_product_onlist,
     join_multi_onlist,
+    join_onlists,
     run_onlist_region,
     run_onlist_read,
 )
@@ -63,30 +64,6 @@ class TestSeqspecOnlist(TestCase):
         target_dir = find_list_target_dir([onlist1])
         self.assertEqual(target_dir, os.getcwd())
 
-    def test_join_one_list_remote_cached_locally(self):
-        with create_temporary_barcode_files(["index_onlist.txt"]):
-            # Can we find a local copy of a  remote list?
-            onlist_name = "index_onlist.txt"
-            onlist1 = Onlist(
-                "http:localhost:9/{}".format(onlist_name),
-                "d41d8cd98f00b204e9800998ecf8427e",
-                "remote")
-
-            filename = join_onlists([onlist1], "multi")
-            self.assertEqual(filename, onlist_name)
-
-    def test_join_multiple_lists_remote_cached_locally(self):
-        # Can we find a local copy of a  remote list?
-        with create_temporary_barcode_files(["index_onlist.txt"]) as tmpdir:
-            onlist_name = "index_onlist.txt"
-            onlist1 = Onlist(
-                "http:localhost:9/{}".format(onlist_name),
-                "d41d8cd98f00b204e9800998ecf8427e",
-                "remote")
-
-            filename = join_onlists([onlist1, onlist1], "multi")
-            self.assertEqual(filename, os.path.join(tmpdir, "onlist_joined.txt"))
-
     def test_join_product_onlist(self):
         onlists = [
             ["AAAA", "TTTT"],
@@ -98,6 +75,17 @@ class TestSeqspecOnlist(TestCase):
         self.assertEqual(joined[0], "AAAAGGGG\n")
         self.assertEqual(joined[3], "TTTTCCCC\n")
 
+    def test_join_onlist_product(self):
+        onlists = [
+            ["AAAA", "TTTT"],
+            ["GGGG", "CCCC"],
+        ]
+
+        joined = list(join_onlists(onlists, "product"))
+        self.assertEqual(len(joined), 4)
+        self.assertEqual(joined[0], "AAAAGGGG\n")
+        self.assertEqual(joined[3], "TTTTCCCC\n")
+
     def test_join_multi_onlist(self):
         onlists = [
             ["AAAA", "TTTT"],
@@ -105,6 +93,18 @@ class TestSeqspecOnlist(TestCase):
         ]
 
         joined = list(join_multi_onlist(onlists))
+        self.assertEqual(len(joined), 3)
+        self.assertEqual(joined[0], "AAAA GGGG\n")
+        self.assertEqual(joined[1], "TTTT CCCC\n")
+        self.assertEqual(joined[2], "- GGTT\n")
+
+    def test_join_onlist_multi(self):
+        onlists = [
+            ["AAAA", "TTTT"],
+            ["GGGG", "CCCC", "GGTT"],
+        ]
+
+        joined = list(join_onlists(onlists, "multi"))
         self.assertEqual(len(joined), 3)
         self.assertEqual(joined[0], "AAAA GGGG\n")
         self.assertEqual(joined[1], "TTTT CCCC\n")

--- a/tests/test_seqspec_onlist.py
+++ b/tests/test_seqspec_onlist.py
@@ -13,8 +13,7 @@ from seqspec.seqspec_onlist import (
     run_onlist_region,
     run_onlist_read,
 )
-from seqspec.utils import load_spec_stream
-from .test_utils import example_spec
+from .test_utils import example_spec, load_example_spec
 
 
 @contextmanager
@@ -38,16 +37,14 @@ def create_temporary_barcode_files(filenames):
 class TestSeqspecOnlist(TestCase):
     def test_run_onlist_region(self):
         with create_temporary_barcode_files(["index_onlist.txt"]):
-            with StringIO(example_spec) as instream:
-                spec = load_spec_stream(instream)
+            spec = load_example_spec(example_spec)
             # returns the one local barcode path
             regions = run_onlist_region(spec, "rna", "index", "multi")
             self.assertEqual(regions, "index_onlist.txt")
 
     def test_run_onlist_read(self):
         with create_temporary_barcode_files(["index_onlist.txt"]):
-            with StringIO(example_spec) as instream:
-                spec = load_spec_stream(instream)
+            spec = load_example_spec(example_spec)
             reads = run_onlist_read(spec, "rna", "read2.fastq.gz", "multi")
             self.assertEqual(reads, "index_onlist.txt")
 

--- a/tests/test_seqspec_onlist.py
+++ b/tests/test_seqspec_onlist.py
@@ -40,14 +40,22 @@ class TestSeqspecOnlist(TestCase):
         with create_temporary_barcode_files(["index_onlist.txt"]):
             spec = load_example_spec(example_spec)
             # returns the one local barcode path
-            regions = run_onlist_region(spec, "rna", "index", "multi")
-            self.assertEqual(regions, "index_onlist.txt")
+            regions = run_onlist_region(spec, "rna", "index")
+            self.assertEqual(len(regions), 1)
+            region = regions[0]
+            self.assertEqual(region.location, "local")
+            self.assertEqual(region.filename, "index_onlist.txt")
+            self.assertEqual(region.md5, "939cb244b4c43248fcc795bbe79599b0")
 
     def test_run_onlist_read(self):
         with create_temporary_barcode_files(["index_onlist.txt"]):
             spec = load_example_spec(example_spec)
-            reads = run_onlist_read(spec, "rna", "read2.fastq.gz", "multi")
-            self.assertEqual(reads, "index_onlist.txt")
+            reads = run_onlist_read(spec, "rna", "read2.fastq.gz")
+            self.assertEqual(len(reads), 1)
+            read = reads[0]
+            self.assertEqual(read.location, "local")
+            self.assertEqual(read.filename, "index_onlist.txt")
+            self.assertEqual(read.md5, "939cb244b4c43248fcc795bbe79599b0")
 
     def test_find_list_target_dir_local(self):
         with create_temporary_barcode_files(["index_onlist.txt"]) as tmpdir:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,7 +13,6 @@ from seqspec.Region import (
 )
 from seqspec.utils import (
     get_remote_auth_token,
-    find_onlist_file,
     load_spec_stream,
     map_read_id_to_regions,
     write_read,
@@ -184,27 +183,6 @@ class TestUtils(TestCase):
 
         response = list(yield_onlist_contents(fake_stream))
         self.assertEqual(response, fake_onlist)
-
-    def test_find_onlist_file_local_copy(self):
-        test_dir = Path(__file__).parent
-        test_file = test_dir / "test_utils.py"
-        test_url = "https://example.com" + str(test_file)
-        test_onlist_local_copy = Onlist(test_url, "md5sum", "remote")
-        location, filename = find_onlist_file(test_onlist_local_copy)
-        self.assertEqual(location, "local")
-        self.assertEqual(filename, str(test_file))
-
-    def test_find_onlist_remote_file(self):
-        test_url = "https://example.com/test/barcode.txt.gz"
-        test_onlist_local_copy = Onlist(test_url, "md5sum", "remote")
-        location, filename = find_onlist_file(test_onlist_local_copy)
-        self.assertEqual(location, "remote")
-        self.assertEqual(filename, test_url)
-
-    def test_find_onlist_local_file(self):
-        test_url = "https://example.com/test/barcode.txt.gz"
-        test_onlist = Onlist(test_url, "md5sum", "local")
-        self.assertRaises(FileNotFoundError, find_onlist_file, test_onlist)
 
     def test_read_list_local(self):
         fake_onlist = ["ATATATAT", "GCGCGCGC"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,7 +16,8 @@ from seqspec.utils import (
     load_spec_stream,
     map_read_id_to_regions,
     write_read,
-    read_list,
+    read_local_list,
+    read_remote_list,
     yield_onlist_contents
 )
 from seqspec import __version__
@@ -184,7 +185,7 @@ class TestUtils(TestCase):
         response = list(yield_onlist_contents(fake_stream))
         self.assertEqual(response, fake_onlist)
 
-    def test_read_list_local(self):
+    def test_read_local_list(self):
         fake_onlist = ["ATATATAT", "GCGCGCGC"]
         fake_contents = "{}\n".format("\n".join(fake_onlist))
         fake_md5 = md5(fake_contents.encode("ascii")).hexdigest()
@@ -195,11 +196,11 @@ class TestUtils(TestCase):
                 stream.write(fake_contents)
 
             onlist1 = Onlist(temp_list_filename, fake_md5, "local")
-            loaded_list = read_list(onlist1)
+            loaded_list = read_local_list(onlist1)
 
             self.assertEqual(fake_onlist, loaded_list)
 
-    def test_read_list_local_gz(self):
+    def test_read_local_list_gz(self):
         fake_onlist = ["ATATATAT", "GCGCGCGC"]
         fake_contents = "{}\n".format("\n".join(fake_onlist))
         fake_md5 = md5(fake_contents.encode("ascii")).hexdigest()
@@ -210,11 +211,11 @@ class TestUtils(TestCase):
                 stream.write(fake_contents)
 
             onlist1 = Onlist(temp_list_filename, fake_md5, "local")
-            loaded_list = read_list(onlist1)
+            loaded_list = read_local_list(onlist1)
 
             self.assertEqual(fake_onlist, loaded_list)
 
-    def test_read_list_remote(self):
+    def test_read_remote_list(self):
         fake_onlist = ["ATATATAT", "GCGCGCGC"]
         fake_contents = "{}\n".format("\n".join(fake_onlist))
         fake_md5 = md5(fake_contents.encode("ascii")).hexdigest()
@@ -233,7 +234,7 @@ class TestUtils(TestCase):
 
         with patch("requests.get", new=fake_request_get):
             onlist1 = Onlist("http://localhost/testlist.txt", fake_md5, "remote")
-            loaded_list = read_list(onlist1)
+            loaded_list = read_remote_list(onlist1)
 
             self.assertEqual(fake_onlist, loaded_list)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,6 +15,7 @@ from seqspec.utils import (
     get_remote_auth_token,
     find_onlist_file,
     load_spec_stream,
+    map_read_id_to_regions,
     write_read,
     read_list,
     yield_onlist_contents
@@ -281,3 +282,20 @@ class TestUtils(TestCase):
                 del os.environ[name]
             else:
                 os.environ[name] = previous[name]
+
+    def test_map_read_id_to_regions(self):
+        spec = load_example_spec(example_spec)
+
+        read1_id = "read1.fastq.gz"
+        read, region = map_read_id_to_regions(spec, "rna", read1_id)
+        self.assertEqual(read.read_id, read1_id)
+        self.assertEqual(len(region), 4)
+        expected_regions = [
+            (0, "cDNA"),
+            (1, "SOLiD_bc_adapter"),
+            (2, "index"),
+            (3, "p2_adapter"),
+        ]
+        for i, region_id in expected_regions:
+            self.assertEqual(region[i].region_id, region_id)
+        self.assertRaises(IndexError, map_read_id_to_regions, spec, "rna", "foo")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -131,11 +131,15 @@ library_spec:
     parent_id: rna
 """
 
+def load_example_spec(spec_text):
+    with StringIO(spec_text) as instream:
+        spec = load_spec_stream(instream)
+    return spec
+
 
 class TestUtils(TestCase):
     def test_load_spec_stream(self):
-        with StringIO(example_spec) as instream:
-            spec = load_spec_stream(instream)
+        spec = load_example_spec(example_spec)
         self.assertEqual(spec.name, "my assay")
         head = spec.get_libspec("rna")
         self.assertEqual(len(head.regions), 5)


### PR DESCRIPTION
This important change is the guaranteed deterministic deduplication function. which would fix https://github.com/pachterlab/seqspec/issues/36

But it also has 2 changes for the tests, a function for loading variables as seqspecs, and a test for another function.

Then there's a change to map_read_id_to_regions to give a more useful error message if it can't find a read id or a region. it throws the same exception if a list comprehension is empty, it's just the error text includes the name of the thing being searched for, and what was being searched against.

I added it to help me debugging a seqspec
