### PR TITLE
 - fix chromap format

### DIFF
--- a/seqspec/seqspec_index.py
+++ b/seqspec/seqspec_index.py
@@ -295,11 +295,11 @@ def format_chromap(indices, subregion_type=None):
             for cut in cuts:
                 if cut.region_type.upper() == "BARCODE":
                     bc_fqs.append(rgn)
-                    bc_str.append(f"bc:{cut.start}:{cut.stop}")
+                    bc_str.append(f"bc:{cut.start}:{cut.stop-1}")
                     pass
                 elif cut.region_type.upper() == "GDNA":
                     gdna_fqs.append(rgn)
-                    gdna_str.append(f"{cut.start}:{cut.stop}")
+                    gdna_str.append(f"{cut.start}:{cut.stop-1}")
     if len(set(bc_fqs)) > 1:
         raise Exception("chromap only supports barcodes from one fastq")
     if len(set(gdna_fqs)) > 2:


### PR DESCRIPTION
chromap's `read_format` is 0-index based. This pull request fixes the end positions of the barcode and read strings in the `seqspec index` subcommand.  