### PR TITLE
support gzipped yaml file for function load_spec

### DIFF
--- a/seqspec/seqspec_check.py
+++ b/seqspec/seqspec_check.py
@@ -40,7 +40,7 @@ def validate_check_args(parser, args):
 def run_check(spec_fn, o):
     spec = load_spec(spec_fn)
 
-    errors = check(spec)
+    errors = check(spec, spec_fn)
 
     if errors:
         if o:
@@ -51,7 +51,7 @@ def run_check(spec_fn, o):
     return errors
 
 
-def check(spec: Assay, spec_fn: str = None):
+def check(spec: Assay, spec_fn: str):
     schema_fn = path.join(path.dirname(__file__), "schema/seqspec.schema.json")
 
     with open(schema_fn, "r") as stream:

--- a/seqspec/utils.py
+++ b/seqspec/utils.py
@@ -13,8 +13,20 @@ from typing import Tuple, List
 
 
 def load_spec(spec_fn: str):
-    with open(spec_fn, "r") as stream:
-        return load_spec_stream(stream)
+    """
+    Reads a YAML file that may be gzipped or not.
+
+    :param spec_fn: Path to the YAML or gzipped YAML file.
+    :return: Parsed YAML content as a Assay object.
+    """
+    try:
+        # Check if the file is gzipped by attempting to open it as such
+        with gzip.open(spec_fn, "rt") as stream:
+            return load_spec_stream(stream)
+    except OSError:
+        # If opening as gzip fails, assume it's a regular YAML file
+        with open(spec_fn, "r") as stream:
+            return load_spec_stream(stream)
 
 
 def load_spec_stream(spec_stream: io.IOBase):

--- a/seqspec/utils.py
+++ b/seqspec/utils.py
@@ -23,7 +23,7 @@ def load_spec(spec_fn: str):
         # Check if the file is gzipped by attempting to open it as such
         with gzip.open(spec_fn, "rt") as stream:
             return load_spec_stream(stream)
-    except OSError:
+    except gzip.BadGzipFile:
         # If opening as gzip fails, assume it's a regular YAML file
         with open(spec_fn, "r") as stream:
             return load_spec_stream(stream)


### PR DESCRIPTION
Update the code to support gzipped yaml file for function load_spec. Also fix bug in function run_check. I think we moved the parameters in and out of the function for check last time and forgot to add spec_fn back when use check function in run_check. 